### PR TITLE
Update EngineControl.h

### DIFF
--- a/src/fadec/src/EngineControl.h
+++ b/src/fadec/src/EngineControl.h
@@ -202,8 +202,18 @@ class EngineControl {
       }
     }
 
-    // Present State Starting
+    // Present State Starting. Fuel used reset to zero
     if (EngineState == 2) {
+      if (simOnGround == 1) {
+          switch (engine){
+            case 1:
+              simVars->setFuelUsedLeft(0);
+              break;
+            case 2:
+              simVars->setFuelUsedRight(0);
+              break;
+          }
+         }
       if (engineStarter == 1 && simN2 >= (idleN2 - 0.1)) {
         EngineState = 1;
         resetTimer = 1;
@@ -217,16 +227,6 @@ class EngineControl {
 
     // Present State Shutting
     if (EngineState == 3) {
-      if (simOnGround == 1) {
-          switch (engine){
-            case 1:
-              simVars->setFuelUsedLeft(0);
-              break;
-            case 2:
-              simVars->setFuelUsedRight(0);
-              break;
-          }
-         }
       if (engineIgniter == 2 && engineStarter == 1) {
         EngineState = 2;
       } else if (engineStarter == 0 && simN2 < 0.05) {


### PR DESCRIPTION
Commit by John Maguire. Fuel burn does not reset on turn over flight #5486. On starting or restarting the engines on the ground the relevant engine fuel burn SimVar is set to zero.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos). P3D/xplane/fsx references will only be accepted if we believe that one cannot reasonably obtain a better source. Please post screenshots of the references you used. Ask around in the discord for how to find references for what you are working on. Exceptions will probably be made for IRL A320 pilots and engineers. -->

<!-- If you are making a pull request related to the MCDU, please make sure you are ONLY referencing the Honeywell Pegasus Step 1A (Rev 0), 2009 edition manual. -->
<!-- If you do not have this manual, please ask on our discord for assistance -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for QA

Every new commit to this PR will cause a new A32NX artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **A32NX** download link at the bottom of the page
